### PR TITLE
Improve event logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - Statistics logging
 - Logging in the Storage Service
+- Router initialization routine
 
 ### Removed
 - Unused code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Statistics logging
 - Logging in the Storage Service
 - Router initialization routine
+- The database function `generic_getblobs`
 
 ### Removed
 - Unused code

--- a/Migrations/Networking.1.3.0.sql
+++ b/Migrations/Networking.1.3.0.sql
@@ -75,6 +75,47 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION generic_getblobs(idlist TEXT,
+                                      start TIMESTAMP,
+                                      "end" TIMESTAMP,
+                                      ofst INTEGER DEFAULT NULL,
+                                      lim INTEGER DEFAULT NULL,
+                                      direction VARCHAR(12) DEFAULT 'ASC'
+                                      )
+    RETURNS TABLE(
+        "ID" BIGINT,
+        "SensorID" VARCHAR(24),
+        "Path" TEXT,
+        "StorageType" INTEGER,
+        "Timestamp" TIMESTAMP,
+        "FileSize" BIGINT
+                 )
+    LANGUAGE plpgsql
+AS $$
+    DECLARE sensorIds VARCHAR(24)[];
+BEGIN
+    sensorIds = ARRAY(SELECT DISTINCT UNNEST(string_to_array(idlist, ',')));
+
+    IF upper(direction) NOT IN ('ASC', 'DESC', 'ASCENDING', 'DESCENDING') THEN
+      RAISE EXCEPTION 'Unexpected value for parameter direction.
+                       Allowed: ASC, DESC, ASCENDING, DESCENDING. Default: ASC';
+   END IF;
+
+	RETURN QUERY EXECUTE
+	    format('SELECT "ID", "SensorID", "Path", "StorageType", "Timestamp", "FileSize" ' ||
+	           'FROM "Blobs" ' ||
+	           'WHERE "Timestamp" >= $1 AND "Timestamp" < $2 AND "SensorID" = ANY($3) ' ||
+	           'ORDER BY "Timestamp" %s ' ||
+	           'OFFSET %s ' ||
+	           'LIMIT %s',
+	        direction, ofst, lim)
+    USING start, "end", sensorIds;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION public.generic_getblobs(text, timestamp without time zone, timestamp without time zone, integer, integer, character varying) TO db_dataapi;
+GRANT EXECUTE ON FUNCTION public.generic_getblobs(text, timestamp without time zone, timestamp without time zone, integer, integer, character varying) TO db_networkapi;
+REVOKE ALL ON FUNCTION public.generic_getblobs(text, timestamp without time zone, timestamp without time zone, integer, integer, character varying) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION triggerservice_gettriggers() TO db_triggerservice;
 GRANT EXECUTE ON FUNCTION triggerservice_gettriggersbysensorid(id VARCHAR(24)) TO db_triggerservice;

--- a/SensateIoT.Platform.Network.API/appsettings.Development.json
+++ b/SensateIoT.Platform.Network.API/appsettings.Development.json
@@ -29,7 +29,7 @@
   },
   "HttpServer": {
     "Metrics": {
-      "Port": 8083,
+      "Port": 6501,
       "Endpoint": "metrics/",
       "Hostname": "localhost"
     }

--- a/SensateIoT.Platform.Network.Common/MQTT/AbstractMqttClient.cs
+++ b/SensateIoT.Platform.Network.Common/MQTT/AbstractMqttClient.cs
@@ -149,7 +149,7 @@ namespace SensateIoT.Platform.Network.Common.MQTT
 			try {
 				await handler.OnMessageAsync(topic, msg).ConfigureAwait(false);
 			} catch(Exception ex) {
-				this._logger.LogWarning($"Unable to handle MQTT message: {ex.Message}");
+				this._logger.LogWarning(ex, "Unable to handle MQTT message.");
 			}
 		}
 

--- a/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
@@ -19,12 +19,12 @@ using Prometheus;
 
 using SensateIoT.Platform.Network.Common.Caching.Abstract;
 using SensateIoT.Platform.Network.Common.Collections.Abstract;
-using SensateIoT.Platform.Network.Common.Collections.Remote;
 using SensateIoT.Platform.Network.Common.Services.Background;
 using SensateIoT.Platform.Network.Common.Settings;
 using SensateIoT.Platform.Network.Contracts.DTO;
 using SensateIoT.Platform.Network.Data.Abstract;
 using SensateIoT.Platform.Network.Data.DTO;
+
 using ControlMessage = SensateIoT.Platform.Network.Data.DTO.ControlMessage;
 
 namespace SensateIoT.Platform.Network.Common.Services.Processing

--- a/SensateIoT.Platform.Network.Data/Enums/StatisticsType.cs
+++ b/SensateIoT.Platform.Network.Data/Enums/StatisticsType.cs
@@ -11,15 +11,13 @@ namespace SensateIoT.Platform.Network.Data.Enums
 	{
 		HttpGet,
 		HttpPost,
-		HttpPatch,
-		HttpPut,
-		HttpDelete,
 		Email,
 		SMS,
 		LiveData,
 		MQTT,
 		ControlMessage,
 		MeasurementStorage,
-		MessageStorage
+		MessageStorage,
+		MessageRouted
 	}
 }

--- a/SensateIoT.Platform.Network.Data/Models/SensorStatisticsEntry.cs
+++ b/SensateIoT.Platform.Network.Data/Models/SensorStatisticsEntry.cs
@@ -24,9 +24,9 @@ namespace SensateIoT.Platform.Network.Data.Models
 		[BsonRequired, JsonConverter(typeof(ObjectIdJsonConverter))]
 		public ObjectId SensorId { get; set; }
 		[BsonRequired]
-		public DateTime Date { get; set; }
+		public DateTime Timestamp { get; set; }
 		[BsonRequired]
-		public int Measurements { get; set; }
-		public StatisticsType Method { get; set; }
+		public int Count { get; set; }
+		public StatisticsType Type { get; set; }
 	}
 }

--- a/SensateIoT.Platform.Network.DataAccess/Repositories/SensorStatisticsRepository.cs
+++ b/SensateIoT.Platform.Network.DataAccess/Repositories/SensorStatisticsRepository.cs
@@ -36,12 +36,12 @@ namespace SensateIoT.Platform.Network.DataAccess.Repositories
 		{
 			var update = Builders<SensorStatisticsEntry>.Update;
 			var opts = new UpdateOptions { IsUpsert = true };
-			var updateDefinition = update.Inc(x => x.Measurements, num)
-				.SetOnInsert(x => x.Method, method);
+			var updateDefinition = update.Inc(x => x.Count, num)
+				.SetOnInsert(x => x.Type, method);
 
 			try {
 				await this._stats.UpdateOneAsync(x => x.SensorId == sensorId &&
-														   x.Date == DateTime.Now.ThisHour() && x.Method == method,
+														   x.Timestamp == DateTime.Now.ThisHour() && x.Type == method,
 					updateDefinition, opts, token).ConfigureAwait(false);
 			} catch(Exception ex) {
 				throw new DataException("Unable to update measurement statistics!", ex);

--- a/SensateIoT.Platform.Network.Database/public/Functions/Generic_GetBlobs.sql
+++ b/SensateIoT.Platform.Network.Database/public/Functions/Generic_GetBlobs.sql
@@ -3,7 +3,7 @@ CREATE FUNCTION generic_getblobs(idlist TEXT,
                                       "end" TIMESTAMP,
                                       ofst INTEGER DEFAULT NULL,
                                       lim INTEGER DEFAULT NULL,
-                                      direction VARCHAR(3) DEFAULT 'ASC'
+                                      direction VARCHAR(12) DEFAULT 'ASC'
                                       )
     RETURNS TABLE(
         "ID" BIGINT,
@@ -31,7 +31,7 @@ BEGIN
 	           'ORDER BY "Timestamp" %s ' ||
 	           'OFFSET %s ' ||
 	           'LIMIT %s',
-	        direction, lim, ofst)
+	        direction, ofst, lim)
     USING start, "end", sensorIds;
 END
 $$;

--- a/SensateIoT.Platform.Network.Router/Application/Startup.cs
+++ b/SensateIoT.Platform.Network.Router/Application/Startup.cs
@@ -14,21 +14,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using Prometheus;
+using JetBrains.Annotations;
 
-using SensateIoT.Platform.Network.Common.Caching.Abstract;
-using SensateIoT.Platform.Network.Common.Caching.Routing;
-using SensateIoT.Platform.Network.Common.Collections.Abstract;
-using SensateIoT.Platform.Network.Common.Collections.Local;
-using SensateIoT.Platform.Network.Common.Collections.Remote;
 using SensateIoT.Platform.Network.Common.Init;
-using SensateIoT.Platform.Network.Common.Services.Data;
-using SensateIoT.Platform.Network.Common.Services.Metrics;
 using SensateIoT.Platform.Network.Common.Services.Processing;
-using SensateIoT.Platform.Network.Common.Settings;
-using SensateIoT.Platform.Network.Data.Abstract;
-using SensateIoT.Platform.Network.DataAccess.Abstract;
-using SensateIoT.Platform.Network.DataAccess.Repositories;
 using SensateIoT.Platform.Network.Router.Config;
+using SensateIoT.Platform.Network.Router.Init;
 using SensateIoT.Platform.Network.Router.MQTT;
 using SensateIoT.Platform.Network.Router.Services;
 
@@ -43,94 +34,30 @@ namespace SensateIoT.Platform.Network.Router.Application
 			this.Configuration = configuration;
 		}
 
+		[UsedImplicitly]
 		public void ConfigureServices(IServiceCollection services)
 		{
 			var db = new DatabaseConfig();
-			var mqtt = new MqttConfig();
 
 			this.Configuration.GetSection("Database").Bind(db);
-			this.Configuration.GetSection("Mqtt").Bind(mqtt);
-
-			var id = this.Configuration.GetValue<string>("ApplicationId");
-			var reload = this.Configuration.GetValue<int>("Cache:DataReloadInterval");
-			var privatemqtt = mqtt.InternalBroker;
-			var publicmqtt = mqtt.PublicBroker;
 
 			services.AddDocumentStore(db.MongoDB.ConnectionString, db.MongoDB.DatabaseName, db.MongoDB.MaxConnections);
 			services.AddConnectionStrings(db.Networking.ConnectionString, db.SensateIoT.ConnectionString);
 			services.AddAuthorizationContext();
 			services.AddNetworkingContext();
-
-			services.Configure<DataReloadSettings>(opts => {
-				opts.StartDelay = TimeSpan.FromSeconds(1);
-				opts.EnableReload = this.Configuration.GetValue<bool>("Cache:EnableReload");
-
-				/* Default to 30 minutes for live data handler reload */
-				opts.DataReloadInterval = reload == 0 ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(reload);
-				opts.LiveDataReloadInterval = TimeSpan.FromSeconds(this.Configuration.GetValue<int>("Cache:LiveDataReloadInterval"));
-				opts.TimeoutScanInterval = TimeSpan.FromSeconds(this.Configuration.GetValue<int>("Cache:TimeoutScanInterval"));
-			});
-
-			services.Configure<QueueSettings>(s => {
-				s.LiveDataQueueTemplate = this.Configuration.GetValue<string>("Routing:LiveDataTopic");
-				s.TriggerQueueTemplate = this.Configuration.GetValue<string>("Routing:TriggerTopic");
-				s.MessageStorageQueueTopic = this.Configuration.GetValue<string>("Routing:MessageStorageQueueTopic");
-				s.MeasurementStorageQueueTopic = this.Configuration.GetValue<string>("Routing:MeasurementStorageQueueTopic");
-				s.NetworkEventQueueTopic = this.Configuration.GetValue<string>("Routing:NetworkEventQueueTopic");
-			});
-
-			services.Configure<RoutingPublishSettings>(s => {
-				s.InternalInterval = TimeSpan.FromMilliseconds(this.Configuration.GetValue<int>("Routing:InternalPublishInterval"));
-				s.PublicInterval = TimeSpan.FromMilliseconds(this.Configuration.GetValue<int>("Routing:PublicPublishInterval"));
-				s.ActuatorTopicFormat = this.Configuration.GetValue<string>("Routing:ActuatorTopicFormat");
-			});
-
-			services.Configure<MetricsOptions>(this.Configuration.GetSection("HttpServer:Metrics"));
-
-			services.AddInternalMqttService(options => {
-				options.Ssl = privatemqtt.Ssl;
-				options.Host = privatemqtt.Host;
-				options.Port = privatemqtt.Port;
-				options.Username = privatemqtt.Username;
-				options.Password = privatemqtt.Password;
-				options.Id = $"router-{id}";
-			});
-
-			services.AddMqttService(options => {
-				options.Ssl = publicmqtt.Ssl;
-				options.Host = publicmqtt.Host;
-				options.Port = publicmqtt.Port;
-				options.Username = publicmqtt.Username;
-				options.Password = publicmqtt.Password;
-				options.Id = $"router-{id}-{Guid.NewGuid():N}";
-			});
-
-			services.AddScoped<IRoutingRepository, RoutingRepository>();
-			services.AddScoped<ILiveDataHandlerRepository, LiveDataHandlerRepository>();
+			services.AddRoutingServices(this.Configuration);
+			services.AddBackgroundServices(this.Configuration);
+			services.AddMqttBrokers(this.Configuration);
 
 			services.AddSingleton<CommandCounter>();
-			services.AddSingleton<IQueue<IPlatformMessage>, Deque<IPlatformMessage>>();
-			services.AddSingleton<IMessageQueue, MessageQueue>();
-			services.AddSingleton<IRemoteNetworkEventQueue, RemoteNetworkEventQueue>();
-			services.AddSingleton<IInternalRemoteQueue, InternalMqttQueue>();
-			services.AddSingleton<IPublicRemoteQueue, PublicMqttQueue>();
 			services.AddSingleton<IAuthorizationService, AuthorizationService>();
-			services.AddSingleton<IRemoteStorageQueue, RemoteStorageQueue>();
-			services.AddSingleton<IRoutingCache, RoutingCache>();
-
-			services.AddSingleton<IHostedService, DataReloadService>();
-			services.AddSingleton<IHostedService, CacheTimeoutScanService>();
-			services.AddSingleton<IHostedService, LiveDataReloadService>();
-			services.AddSingleton<IHostedService, RoutingPublishService>();
-			services.AddSingleton<IHostedService, ActuatorPublishService>();
-			services.AddSingleton<IHostedService, RoutingService>();
-			services.AddSingleton<IHostedService, MetricsService>();
 
 			services.AddGrpc();
 			services.AddGrpcReflection();
 			services.AddMqttHandlers();
 		}
 
+		[UsedImplicitly]
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IServiceProvider provider)
 		{
 			var mqtt = new MqttConfig();

--- a/SensateIoT.Platform.Network.Router/Application/Startup.cs
+++ b/SensateIoT.Platform.Network.Router/Application/Startup.cs
@@ -17,7 +17,6 @@ using Prometheus;
 using JetBrains.Annotations;
 
 using SensateIoT.Platform.Network.Common.Init;
-using SensateIoT.Platform.Network.Common.Services.Processing;
 using SensateIoT.Platform.Network.Router.Config;
 using SensateIoT.Platform.Network.Router.Init;
 using SensateIoT.Platform.Network.Router.MQTT;
@@ -50,7 +49,6 @@ namespace SensateIoT.Platform.Network.Router.Application
 			services.AddMqttBrokers(this.Configuration);
 
 			services.AddSingleton<CommandCounter>();
-			services.AddSingleton<IAuthorizationService, AuthorizationService>();
 
 			services.AddGrpc();
 			services.AddGrpcReflection();

--- a/SensateIoT.Platform.Network.Router/Init/BackgroundServiceInitExtensions.cs
+++ b/SensateIoT.Platform.Network.Router/Init/BackgroundServiceInitExtensions.cs
@@ -23,6 +23,7 @@ namespace SensateIoT.Platform.Network.Router.Init
 			services.AddSingleton<IHostedService, RoutingPublishService>();
 			services.AddSingleton<IHostedService, ActuatorPublishService>();
 			services.AddSingleton<IHostedService, MetricsService>();
+			services.AddSingleton<IAuthorizationService, AuthorizationService>();
 
 			services.Configure<MetricsOptions>(configuration.GetSection("HttpServer:Metrics"));
 			services.Configure<DataReloadSettings>(opts => {

--- a/SensateIoT.Platform.Network.Router/Init/BackgroundServiceInitExtensions.cs
+++ b/SensateIoT.Platform.Network.Router/Init/BackgroundServiceInitExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using SensateIoT.Platform.Network.Common.Services.Data;
+using SensateIoT.Platform.Network.Common.Services.Metrics;
+using SensateIoT.Platform.Network.Common.Services.Processing;
+using SensateIoT.Platform.Network.Common.Settings;
+
+namespace SensateIoT.Platform.Network.Router.Init
+{
+	public static class BackgroundServiceInitExtensions
+	{
+		public static void AddBackgroundServices(this IServiceCollection services, IConfiguration configuration)
+		{
+			var reload = configuration.GetValue<int>("Cache:DataReloadInterval");
+
+			services.AddSingleton<IHostedService, DataReloadService>();
+			services.AddSingleton<IHostedService, CacheTimeoutScanService>();
+			services.AddSingleton<IHostedService, LiveDataReloadService>();
+			services.AddSingleton<IHostedService, RoutingPublishService>();
+			services.AddSingleton<IHostedService, ActuatorPublishService>();
+			services.AddSingleton<IHostedService, MetricsService>();
+
+			services.Configure<MetricsOptions>(configuration.GetSection("HttpServer:Metrics"));
+			services.Configure<DataReloadSettings>(opts => {
+				opts.StartDelay = TimeSpan.FromSeconds(1);
+				opts.EnableReload = configuration.GetValue<bool>("Cache:EnableReload");
+
+				/* Default to 30 minutes for live data handler reload */
+				opts.DataReloadInterval = reload == 0 ? TimeSpan.FromMinutes(30) : TimeSpan.FromSeconds(reload);
+				opts.LiveDataReloadInterval = TimeSpan.FromSeconds(configuration.GetValue<int>("Cache:LiveDataReloadInterval"));
+				opts.TimeoutScanInterval = TimeSpan.FromSeconds(configuration.GetValue<int>("Cache:TimeoutScanInterval"));
+			});
+		}
+	}
+}

--- a/SensateIoT.Platform.Network.Router/Init/MqttInitExtensions.cs
+++ b/SensateIoT.Platform.Network.Router/Init/MqttInitExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SensateIoT.Platform.Network.Common.Init;
+using SensateIoT.Platform.Network.Router.Config;
+
+namespace SensateIoT.Platform.Network.Router.Init
+{
+	public static class MqttInitExtensions
+	{
+		public static void AddMqttBrokers(this IServiceCollection services, IConfiguration configuration)
+		{
+			var id = configuration.GetValue<string>("ApplicationId");
+			var mqtt = new MqttConfig();
+
+			configuration.GetSection("Mqtt").Bind(mqtt);
+			var privatemqtt = mqtt.InternalBroker;
+			var publicmqtt = mqtt.PublicBroker;
+
+			services.AddInternalMqttService(options => {
+				options.Ssl = privatemqtt.Ssl;
+				options.Host = privatemqtt.Host;
+				options.Port = privatemqtt.Port;
+				options.Username = privatemqtt.Username;
+				options.Password = privatemqtt.Password;
+				options.Id = $"router-{id}";
+			});
+
+			services.AddMqttService(options => {
+				options.Ssl = publicmqtt.Ssl;
+				options.Host = publicmqtt.Host;
+				options.Port = publicmqtt.Port;
+				options.Username = publicmqtt.Username;
+				options.Password = publicmqtt.Password;
+				options.Id = $"router-{id}-{Guid.NewGuid():N}";
+			});
+
+		}
+	}
+}

--- a/SensateIoT.Platform.Network.Router/Init/RoutingInitExtensions.cs
+++ b/SensateIoT.Platform.Network.Router/Init/RoutingInitExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using SensateIoT.Platform.Network.Common.Caching.Abstract;
+using SensateIoT.Platform.Network.Common.Caching.Routing;
+using SensateIoT.Platform.Network.Common.Collections.Abstract;
+using SensateIoT.Platform.Network.Common.Collections.Local;
+using SensateIoT.Platform.Network.Common.Collections.Remote;
+using SensateIoT.Platform.Network.Common.Services.Processing;
+using SensateIoT.Platform.Network.Common.Settings;
+using SensateIoT.Platform.Network.Data.Abstract;
+using SensateIoT.Platform.Network.DataAccess.Abstract;
+using SensateIoT.Platform.Network.DataAccess.Repositories;
+
+namespace SensateIoT.Platform.Network.Router.Init
+{
+	public static class RoutingInitExtensions
+	{
+		public static void AddRoutingServices(this IServiceCollection services, IConfiguration configuration)
+		{
+			AddRoutingService(services, configuration);
+			AddQueues(services, configuration);
+
+			// Data repository's
+			services.AddScoped<IRoutingRepository, RoutingRepository>();
+			services.AddScoped<ILiveDataHandlerRepository, LiveDataHandlerRepository>();
+		}
+
+		private static void AddRoutingService(IServiceCollection services, IConfiguration configuration)
+		{
+			services.AddSingleton<IRoutingCache, RoutingCache>();
+			services.AddSingleton<IHostedService, RoutingService>();
+
+			services.Configure<RoutingPublishSettings>(s => {
+				s.InternalInterval = TimeSpan.FromMilliseconds(configuration.GetValue<int>("Routing:InternalPublishInterval"));
+				s.PublicInterval = TimeSpan.FromMilliseconds(configuration.GetValue<int>("Routing:PublicPublishInterval"));
+				s.ActuatorTopicFormat = configuration.GetValue<string>("Routing:ActuatorTopicFormat");
+			});
+		}
+
+		private static void AddQueues(IServiceCollection services, IConfiguration configuration)
+		{
+			// Routing queues
+			services.AddSingleton<IQueue<IPlatformMessage>, Deque<IPlatformMessage>>();
+			services.AddSingleton<IMessageQueue, MessageQueue>();
+			services.AddSingleton<IRemoteNetworkEventQueue, RemoteNetworkEventQueue>();
+			services.AddSingleton<IInternalRemoteQueue, InternalMqttQueue>();
+			services.AddSingleton<IPublicRemoteQueue, PublicMqttQueue>();
+			services.AddSingleton<IRemoteStorageQueue, RemoteStorageQueue>();
+
+			services.Configure<QueueSettings>(s => {
+				s.LiveDataQueueTemplate = configuration.GetValue<string>("Routing:LiveDataTopic");
+				s.TriggerQueueTemplate = configuration.GetValue<string>("Routing:TriggerTopic");
+				s.MessageStorageQueueTopic = configuration.GetValue<string>("Routing:MessageStorageQueueTopic");
+				s.MeasurementStorageQueueTopic = configuration.GetValue<string>("Routing:MeasurementStorageQueueTopic");
+				s.NetworkEventQueueTopic = configuration.GetValue<string>("Routing:NetworkEventQueueTopic");
+			});
+		}
+	}
+}

--- a/SensateIoT.Platform.Network.StorageService/Application/Startup.cs
+++ b/SensateIoT.Platform.Network.StorageService/Application/Startup.cs
@@ -92,6 +92,8 @@ namespace SensateIoT.Platform.Network.StorageService.Application
 
 			provider.MapInternalMqttTopic<MqttBulkMeasurementHandler>(@private.BulkMeasurementTopic);
 			provider.MapInternalMqttTopic<MqttBulkMessageHandler>(@private.BulkMessageTopic);
+			provider.MapInternalMqttTopic<MqttNetworkEventConsumer>(@private.NetworkEventQueueTopic);
+			provider.MapInternalMqttTopic<MqttTriggerEventConsumer>(@private.TriggerEventQueueTopic);
 		}
 	}
 }

--- a/SensateIoT.Platform.Network.StorageService/Config/InternalBrokerConfig.cs
+++ b/SensateIoT.Platform.Network.StorageService/Config/InternalBrokerConfig.cs
@@ -5,8 +5,11 @@
  * @email  michel@michelmegens.net
  */
 
+using JetBrains.Annotations;
+
 namespace SensateIoT.Platform.Network.StorageService.Config
 {
+	[UsedImplicitly]
 	public class InternalBrokerConfig
 	{
 		public string Username { get; set; }
@@ -16,5 +19,7 @@ namespace SensateIoT.Platform.Network.StorageService.Config
 		public short Port { get; set; }
 		public string BulkMeasurementTopic { get; set; }
 		public string BulkMessageTopic { get; set; }
+		public string TriggerEventQueueTopic { get; set; }
+		public string NetworkEventQueueTopic { get; set; }
 	}
 }

--- a/SensateIoT.Platform.Network.StorageService/MQTT/MqttBulkMeasurementHandler.cs
+++ b/SensateIoT.Platform.Network.StorageService/MQTT/MqttBulkMeasurementHandler.cs
@@ -67,7 +67,7 @@ namespace SensateIoT.Platform.Network.StorageService.MQTT
 		private async Task HandleMessage(string message, CancellationToken ct)
 		{
 			var measurementMap = MeasurementDatabaseConverter.Convert(this.DeserializeMeasurements(message));
-			var stats = measurementMap.Select(m => new StatisticsUpdate(StatisticsType.MessageStorage, m.Value.Count, m.Key));
+			var stats = measurementMap.Select(m => new StatisticsUpdate(StatisticsType.MeasurementStorage, m.Value.Count, m.Key));
 			var count = measurementMap.Aggregate(0L, (l, pair) => l + pair.Value.Count);
 
 			this.m_storageCounter.Inc(count);

--- a/SensateIoT.Platform.Network.StorageService/MQTT/MqttNetworkEventConsumer.cs
+++ b/SensateIoT.Platform.Network.StorageService/MQTT/MqttNetworkEventConsumer.cs
@@ -64,7 +64,7 @@ namespace SensateIoT.Platform.Network.StorageService.MQTT
 			gzip.CopyTo(to);
 			var final = to.ToArray();
 			var networkEventData = NetworkEventData.Parser.ParseFrom(final);
-			this.m_logger.LogInformation("Storing {count} messages!", networkEventData.Events.Count);
+			this.m_logger.LogInformation("Storing {count} network events!", networkEventData.Events.Count);
 
 			return networkEventData.Events;
 		}

--- a/SensateIoT.Platform.Network.StorageService/MQTT/MqttNetworkEventConsumer.cs
+++ b/SensateIoT.Platform.Network.StorageService/MQTT/MqttNetworkEventConsumer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using JetBrains.Annotations;
+using MongoDB.Bson;
+
+using SensateIoT.Platform.Network.Common.MQTT;
+using SensateIoT.Platform.Network.Contracts.DTO;
+using SensateIoT.Platform.Network.Data.Enums;
+using SensateIoT.Platform.Network.DataAccess.Abstract;
+
+namespace SensateIoT.Platform.Network.StorageService.MQTT
+{
+	[UsedImplicitly]
+	public class MqttNetworkEventConsumer : IMqttHandler
+	{
+		private readonly ISensorStatisticsRepository m_stats;
+		private readonly ILogger<MqttTriggerEventConsumer> m_logger;
+
+		public MqttNetworkEventConsumer(ISensorStatisticsRepository stats, ILogger<MqttTriggerEventConsumer> logger)
+		{
+			this.m_stats = stats;
+			this.m_logger = logger;
+		}
+
+		public async Task OnMessageAsync(string topic, string message, CancellationToken ct = default)
+		{
+			var data = this.Decompress(message);
+			var tasks = new List<Task>();
+
+			foreach(var networkEvent in data) {
+				var id = new ObjectId(networkEvent.SensorID.ToByteArray());
+				var count = 0;
+
+				foreach(var action in networkEvent.Actions) {
+					if(action == NetworkEventType.MessageLiveData ||
+					   action == NetworkEventType.MessageTriggered) {
+						count += 1;
+					}
+				}
+
+				if(count > 0) {
+					tasks.Add(this.m_stats.IncrementManyAsync(id, StatisticsType.MessageRouted, count, ct));
+				}
+
+			}
+
+			await Task.WhenAll(tasks).ConfigureAwait(false);
+		}
+
+		private IEnumerable<NetworkEvent> Decompress(string data)
+		{
+			var bytes = Convert.FromBase64String(data);
+			using var to = new MemoryStream();
+			using var from = new MemoryStream(bytes);
+			using var gzip = new GZipStream(from, CompressionMode.Decompress);
+
+			gzip.CopyTo(to);
+			var final = to.ToArray();
+			var networkEventData = NetworkEventData.Parser.ParseFrom(final);
+			this.m_logger.LogInformation("Storing {count} messages!", networkEventData.Events.Count);
+
+			return networkEventData.Events;
+		}
+	}
+}

--- a/SensateIoT.Platform.Network.StorageService/MQTT/MqttTriggerEventConsumer.cs
+++ b/SensateIoT.Platform.Network.StorageService/MQTT/MqttTriggerEventConsumer.cs
@@ -52,7 +52,7 @@ namespace SensateIoT.Platform.Network.StorageService.MQTT
 			gzip.CopyTo(to);
 			var final = to.ToArray();
 			var triggerEventData = TriggerEventData.Parser.ParseFrom(final);
-			this.m_logger.LogInformation("Storing {count} messages!", triggerEventData.Events.Count);
+			this.m_logger.LogInformation("Storing {count} trigger events!", triggerEventData.Events.Count);
 
 			return triggerEventData.Events;
 		}

--- a/SensateIoT.Platform.Network.StorageService/MQTT/MqttTriggerEventConsumer.cs
+++ b/SensateIoT.Platform.Network.StorageService/MQTT/MqttTriggerEventConsumer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using JetBrains.Annotations;
+using MongoDB.Bson;
+
+using SensateIoT.Platform.Network.Common.MQTT;
+using SensateIoT.Platform.Network.Contracts.DTO;
+using SensateIoT.Platform.Network.Data.Enums;
+using SensateIoT.Platform.Network.DataAccess.Abstract;
+
+namespace SensateIoT.Platform.Network.StorageService.MQTT
+{
+	[UsedImplicitly]
+	public class MqttTriggerEventConsumer : IMqttHandler
+	{
+		private readonly ISensorStatisticsRepository m_stats;
+		private readonly ILogger<MqttTriggerEventConsumer> m_logger;
+
+		public MqttTriggerEventConsumer(ISensorStatisticsRepository stats, ILogger<MqttTriggerEventConsumer> logger)
+		{
+			this.m_stats = stats;
+			this.m_logger = logger;
+		}
+
+		public async Task OnMessageAsync(string topic, string message, CancellationToken ct = default)
+		{
+			var data = this.Decompress(message);
+			var tasks = new List<Task>();
+
+			foreach(var triggerEvent in data) {
+				var id = new ObjectId(triggerEvent.SensorID.ToByteArray());
+				tasks.Add(this.m_stats.IncrementManyAsync(id, ConvertTriggerType(triggerEvent.Type), 1, ct));
+			}
+
+			await Task.WhenAll(tasks).ConfigureAwait(false);
+		}
+
+		private IEnumerable<TriggerEvent> Decompress(string data)
+		{
+			var bytes = Convert.FromBase64String(data);
+			using var to = new MemoryStream();
+			using var from = new MemoryStream(bytes);
+			using var gzip = new GZipStream(from, CompressionMode.Decompress);
+
+			gzip.CopyTo(to);
+			var final = to.ToArray();
+			var triggerEventData = TriggerEventData.Parser.ParseFrom(final);
+			this.m_logger.LogInformation("Storing {count} messages!", triggerEventData.Events.Count);
+
+			return triggerEventData.Events;
+		}
+
+		private static StatisticsType ConvertTriggerType(TriggerEventType type)
+		{
+			var result = type switch {
+				TriggerEventType.Email => StatisticsType.Email,
+				TriggerEventType.Sms => StatisticsType.SMS,
+				TriggerEventType.LiveData => StatisticsType.LiveData,
+				TriggerEventType.Mqtt => StatisticsType.MQTT,
+				TriggerEventType.HttpPost => StatisticsType.HttpPost,
+				TriggerEventType.HttpGet => StatisticsType.HttpGet,
+				TriggerEventType.ControlMessage => StatisticsType.ControlMessage,
+				_ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+			};
+
+			return result;
+		}
+	}
+}

--- a/SensateIoT.Platform.Network.StorageService/appsettings.json
+++ b/SensateIoT.Platform.Network.StorageService/appsettings.json
@@ -12,8 +12,10 @@
   },
   "Mqtt": {
     "InternalBroker": {
-      "BulkMeasurementTopic": "$share/sensateiot-storage/sensateiot/storage/internal/measurements/bulk",
-      "BulkMessageTopic": "$share/sensateiot-storage/sensateiot/storage/internal/messages/bulk",
+      "BulkMeasurementTopic":   "$share/sensateiot-storage/sensateiot/storage/internal/measurements/bulk",
+      "BulkMessageTopic":       "$share/sensateiot-storage/sensateiot/storage/internal/messages/bulk",
+      "TriggerEventQueueTopic": "$share/sensateiot-storage/sensateiot/triggers/internal/events/bulk",
+      "NetworkEventQueueTopic": "$share/sensateiot-storage/sensateiot/router/internal/events/bulk",
       "ActuatorTopicFormat": "sensateiot/actuators/$id"
     }
   }

--- a/SensateIoT.Platform.Network.TriggerService/MQTT/MqttRegexTriggerHandler.cs
+++ b/SensateIoT.Platform.Network.TriggerService/MQTT/MqttRegexTriggerHandler.cs
@@ -93,7 +93,9 @@ namespace SensateIoT.Platform.Network.TriggerService.MQTT
 					}
 				}
 
-				await this.PublishAsync(data).ConfigureAwait(false);
+				if(data.Events.Count > 0) {
+					await this.PublishAsync(data).ConfigureAwait(false);
+				}
 			} catch(Exception ex) {
 				this.m_logger.LogError(ex, "Unable to handle a trigger.");
 			}


### PR DESCRIPTION
Improve event logging across the Sensate IoT Platform.

## Description
Various events are now logged to the Metrics database (into the `Statistics` collection). This collection only collects aggregates of events, on an hourly basis. The metrics database has been expanded with a view that is specifically designed to simplify reporting based on these metrics. This view is called `SystemStatistics`. Due to this improvement, the trigger invocations table is no longer needed and can be removed from the Networking DB. This is included in the migration to version 1.3.0 of the Networking database.

## Motivation and Context
Customers of the Sensate IoT Data Platform could not be properly invoiced based on their actual usage of the platform.

## How Has This Been Tested?
Manual tests have been performed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

