### PR TITLE
Improve error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Exception handing to services
+- Fatal to the background service when exceptions are not handled
+- Timestamps to the live data service log statements
+
+### Updated
+- Access modifier of the background servic execute method
+- Live data service logging statements
+
 ## [1.6.0] - 16-03-2021
 ### Added
 - Caching of trigger actions in the Trigger Service

--- a/SensateIoT.Platform.Network.API/Services/BatchRoutingService.cs
+++ b/SensateIoT.Platform.Network.API/Services/BatchRoutingService.cs
@@ -32,7 +32,7 @@ namespace SensateIoT.Platform.Network.API.Services
 			this.m_logger = logger;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			try {
 				await Task.WhenAll(this.m_measurements.ProcessAsync(), this.m_messages.ProcessAsync())

--- a/SensateIoT.Platform.Network.API/Services/BatchRoutingService.cs
+++ b/SensateIoT.Platform.Network.API/Services/BatchRoutingService.cs
@@ -25,7 +25,7 @@ namespace SensateIoT.Platform.Network.API.Services
 		public BatchRoutingService(IMeasurementAuthorizationService measurements,
 								   IMessageAuthorizationService messages,
 								   ILogger<BatchRoutingService> logger) :
-			base(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500))
+			base(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(500), logger)
 		{
 			this.m_measurements = measurements;
 			this.m_messages = messages;

--- a/SensateIoT.Platform.Network.Common/MQTT/AbstractMqttClient.cs
+++ b/SensateIoT.Platform.Network.Common/MQTT/AbstractMqttClient.cs
@@ -46,7 +46,7 @@ namespace SensateIoT.Platform.Network.Common.MQTT
 									 string share,
 									 string id,
 									 ILogger logger,
-									 IServiceProvider provider)
+									 IServiceProvider provider) : base(logger)
 		{
 			this._host = host;
 			this._port = port;

--- a/SensateIoT.Platform.Network.Common/MQTT/InternalMqttClient.cs
+++ b/SensateIoT.Platform.Network.Common/MQTT/InternalMqttClient.cs
@@ -29,7 +29,7 @@ namespace SensateIoT.Platform.Network.Common.MQTT
 			this._options = options.Value;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			await this.Connect(this._options.Username, this._options.Password).ConfigureAwait(false);
 		}

--- a/SensateIoT.Platform.Network.Common/MQTT/MqttClient.cs
+++ b/SensateIoT.Platform.Network.Common/MQTT/MqttClient.cs
@@ -29,7 +29,7 @@ namespace SensateIoT.Platform.Network.Common.MQTT
 			this._options = options.Value;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			await this.Connect(this._options.Username, this._options.Password).ConfigureAwait(false);
 		}

--- a/SensateIoT.Platform.Network.Common/Services/Background/BackgroundService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Background/BackgroundService.cs
@@ -24,7 +24,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Background
 			this.m_stoppingCts = new CancellationTokenSource();
 		}
 
-		public abstract Task ExecuteAsync(CancellationToken token);
+		protected abstract Task ExecuteAsync(CancellationToken token);
 
 		public virtual Task StartAsync(CancellationToken cancellationToken)
 		{

--- a/SensateIoT.Platform.Network.Common/Services/Background/BackgroundService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Background/BackgroundService.cs
@@ -10,25 +10,30 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace SensateIoT.Platform.Network.Common.Services.Background
 {
 	public abstract class BackgroundService : IHostedService, IDisposable
 	{
 		private Task m_executor;
+		private readonly ILogger m_logger;
+
 		protected readonly CancellationTokenSource m_stoppingCts;
 
-		protected BackgroundService()
+		protected BackgroundService(ILogger logger)
 		{
 			this.m_executor = Task.CompletedTask;
 			this.m_stoppingCts = new CancellationTokenSource();
+			this.m_logger = logger;
 		}
 
 		protected abstract Task ExecuteAsync(CancellationToken token);
 
 		public virtual Task StartAsync(CancellationToken cancellationToken)
 		{
-			this.m_executor = this.ExecuteAsync(this.m_stoppingCts.Token);
+			var merged = CancellationTokenSource.CreateLinkedTokenSource(this.m_stoppingCts.Token, cancellationToken);
+			this.m_executor = this.InternalExecuteAsync(merged.Token);
 
 			return this.m_executor.IsCompleted ? this.m_executor : Task.CompletedTask;
 		}
@@ -43,6 +48,16 @@ namespace SensateIoT.Platform.Network.Common.Services.Background
 				this.m_stoppingCts.Cancel();
 			} finally {
 				await Task.WhenAny(this.m_executor, Task.Delay(Timeout.Infinite, cancellationToken));
+			}
+		}
+
+		private async Task InternalExecuteAsync(CancellationToken ct)
+		{
+			try {
+				await this.ExecuteAsync(ct).ConfigureAwait(false);
+			} catch(Exception ex) {
+				this.m_logger.LogCritical(ex, "Unable to complete background service execution!");
+				Environment.Exit(1);
 			}
 		}
 

--- a/SensateIoT.Platform.Network.Common/Services/Background/TimedBackgroundService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Background/TimedBackgroundService.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace SensateIoT.Platform.Network.Common.Services.Background
 {
@@ -18,7 +19,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Background
 		private readonly TimeSpan m_startDelay;
 		private readonly TimeSpan m_interval;
 
-		protected TimedBackgroundService(TimeSpan startDelay, TimeSpan interval)
+		protected TimedBackgroundService(TimeSpan startDelay, TimeSpan interval, ILogger logger) : base(logger)
 		{
 			this.m_startDelay = startDelay;
 			this.m_interval = interval;

--- a/SensateIoT.Platform.Network.Common/Services/Data/CacheTimeoutScanService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/CacheTimeoutScanService.cs
@@ -30,7 +30,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 			this.m_logger = logger;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			this.m_logger.LogInformation("Starting cache clean up!");
 

--- a/SensateIoT.Platform.Network.Common/Services/Data/CacheTimeoutScanService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/CacheTimeoutScanService.cs
@@ -24,7 +24,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 		private readonly ILogger<CacheTimeoutScanService> m_logger;
 
 		public CacheTimeoutScanService(IRoutingCache cache, ILogger<CacheTimeoutScanService> logger, IOptions<DataReloadSettings> settings) :
-			base(settings.Value.TimeoutScanInterval, settings.Value.TimeoutScanInterval)
+			base(settings.Value.TimeoutScanInterval, settings.Value.TimeoutScanInterval, logger)
 		{
 			this.m_cache = cache;
 			this.m_logger = logger;

--- a/SensateIoT.Platform.Network.Common/Services/Data/DataReloadService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/DataReloadService.cs
@@ -38,7 +38,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 											IInternalRemoteQueue internalRemote,
 											IRoutingCache cache,
 											IOptions<DataReloadSettings> settings,
-											ILogger<DataReloadService> logger) : base(settings.Value.StartDelay, settings.Value.DataReloadInterval)
+											ILogger<DataReloadService> logger) : base(settings.Value.StartDelay, settings.Value.DataReloadInterval, logger)
 		{
 			this.m_provider = provider;
 			this.m_queue = internalRemote;

--- a/SensateIoT.Platform.Network.Common/Services/Data/DataReloadService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/DataReloadService.cs
@@ -48,7 +48,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 			this.m_settings = settings.Value;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			await this.ReloadLiveDataHandlers(token).ConfigureAwait(false);
 

--- a/SensateIoT.Platform.Network.Common/Services/Data/LiveDataReloadService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/LiveDataReloadService.cs
@@ -31,7 +31,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 			this.m_cache = cache;
 		}
 
-		public override Task ExecuteAsync(CancellationToken token)
+		protected override Task ExecuteAsync(CancellationToken token)
 		{
 			this.m_logger.LogInformation("Flushing live data routes.");
 			this.m_cache.FlushLiveDataRoutes();

--- a/SensateIoT.Platform.Network.Common/Services/Data/LiveDataReloadService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Data/LiveDataReloadService.cs
@@ -25,7 +25,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Data
 
 		public LiveDataReloadService(IRoutingCache cache,
 									 IOptions<DataReloadSettings> settings,
-									 ILogger<LiveDataReloadService> logger) : base(TimeSpan.FromSeconds(5), settings.Value.LiveDataReloadInterval)
+									 ILogger<LiveDataReloadService> logger) : base(TimeSpan.FromSeconds(5), settings.Value.LiveDataReloadInterval, logger)
 		{
 			this.m_logger = logger;
 			this.m_cache = cache;

--- a/SensateIoT.Platform.Network.Common/Services/Metrics/MetricsService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Metrics/MetricsService.cs
@@ -24,7 +24,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Metrics
 		private readonly ILogger<MetricsService> m_logger;
 		private readonly MetricsOptions m_options;
 
-		public MetricsService(IOptions<MetricsOptions> options, ILogger<MetricsService> logger)
+		public MetricsService(IOptions<MetricsOptions> options, ILogger<MetricsService> logger) : base(logger)
 		{
 			var hostname = options.Value.Hostname;
 

--- a/SensateIoT.Platform.Network.Common/Services/Metrics/MetricsService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Metrics/MetricsService.cs
@@ -47,7 +47,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Metrics
 			this.m_logger = logger;
 		}
 
-		public override Task ExecuteAsync(CancellationToken token)
+		protected override Task ExecuteAsync(CancellationToken token)
 		{
 			this.m_logger.LogInformation("Starting metrics server on http://{hostname}:{port}/{endpoint}",
 										 this.m_options.Hostname,

--- a/SensateIoT.Platform.Network.Common/Services/Processing/ActuatorPublishService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/ActuatorPublishService.cs
@@ -9,9 +9,10 @@ using System.Threading;
 using System;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using SensateIoT.Platform.Network.Common.Collections.Abstract;
-using SensateIoT.Platform.Network.Common.Collections.Remote;
 using SensateIoT.Platform.Network.Common.Services.Background;
 using SensateIoT.Platform.Network.Common.Settings;
 
@@ -22,7 +23,8 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 		private readonly IPublicRemoteQueue m_remote;
 
 		public ActuatorPublishService(IPublicRemoteQueue remote,
-									IOptions<RoutingPublishSettings> options) : base(TimeSpan.FromSeconds(5), options.Value.PublicInterval)
+									IOptions<RoutingPublishSettings> options,
+									ILogger<ActuatorPublishService> logger) : base(TimeSpan.FromSeconds(5), options.Value.PublicInterval, logger)
 		{
 			this.m_remote = remote;
 		}

--- a/SensateIoT.Platform.Network.Common/Services/Processing/ActuatorPublishService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/ActuatorPublishService.cs
@@ -27,7 +27,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 			this.m_remote = remote;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			await this.m_remote.FlushQueueAsync().ConfigureAwait(false);
 		}

--- a/SensateIoT.Platform.Network.Common/Services/Processing/RoutingPublishService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/RoutingPublishService.cs
@@ -9,9 +9,10 @@ using System.Threading;
 using System;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+
 using SensateIoT.Platform.Network.Common.Collections.Abstract;
-using SensateIoT.Platform.Network.Common.Collections.Remote;
 using SensateIoT.Platform.Network.Common.Services.Background;
 using SensateIoT.Platform.Network.Common.Settings;
 
@@ -26,7 +27,8 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 		public RoutingPublishService(IInternalRemoteQueue internalRemote,
 									 IRemoteStorageQueue remoteStorage,
 									 IRemoteNetworkEventQueue remoteEvents,
-									 IOptions<RoutingPublishSettings> options) : base(TimeSpan.FromSeconds(5), options.Value.InternalInterval)
+									 IOptions<RoutingPublishSettings> options,
+									 ILogger<RoutingPublishService> logger) : base(TimeSpan.FromSeconds(5), options.Value.InternalInterval, logger)
 		{
 			this.m_internalRemote = internalRemote;
 			this.m_remoteStorageQueue = remoteStorage;

--- a/SensateIoT.Platform.Network.Common/Services/Processing/RoutingPublishService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/RoutingPublishService.cs
@@ -33,7 +33,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 			this.m_eventQueue = remoteEvents;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			await Task.WhenAll(this.m_internalRemote.FlushAsync(),
 							   this.m_internalRemote.FlushLiveDataAsync(),

--- a/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
@@ -63,7 +63,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 							  IRemoteNetworkEventQueue events,
 							  IAuthorizationService auth,
 							  IOptions<RoutingPublishSettings> settings,
-							  ILogger<RoutingService> logger)
+							  ILogger<RoutingService> logger) : base(logger)
 		{
 			this.m_settings = settings.Value;
 			this.m_messages = queue;

--- a/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
+++ b/SensateIoT.Platform.Network.Common/Services/Processing/RoutingService.cs
@@ -79,7 +79,7 @@ namespace SensateIoT.Platform.Network.Common.Services.Processing
 			this.m_counter = Prometheus.Metrics.CreateCounter("router_messages_routed_total", "Total number of measurements/messages routed.");
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			do {
 				if(this.m_messages.Count <= 0) {

--- a/SensateIoT.Platform.Network.LiveDataService/src/app/live-data-service.ts
+++ b/SensateIoT.Platform.Network.LiveDataService/src/app/live-data-service.ts
@@ -1,8 +1,47 @@
 ﻿
 import * as app from "./app";
 
+function getTimestamp() {
+    const now = new Date();
+    return now.toISOString();
+}
+
+function setupInfo() {
+    const origLog = console.log;
+
+    console.log = function () {
+        const args = [].slice.call(arguments);
+        const ts = `[${getTimestamp()}]: `;
+        origLog.apply(console.log, [ts].concat(args));
+    }
+}
+
+function setupDebug() {
+    const origLog = console.debug;
+
+    console.debug = function () {
+        const args = [].slice.call(arguments);
+        const ts = `[${getTimestamp()}]: `;
+        origLog.apply(console.debug, [ts].concat(args));
+    }
+}
+
+function setupError() {
+    const origLog = console.error;
+
+    console.error = function () {
+        const args = [].slice.call(arguments);
+        const ts = `[${getTimestamp()}]: `;
+        origLog.apply(console.error, [ts].concat(args));
+    }
+}
+
 function setEnvironment() {
     var env = process.env.NODE_ENV || 'development';
+
+    setupInfo();
+    setupDebug();
+    setupError();
 
     if (env === 'production') {
         console.debug = function () { };

--- a/SensateIoT.Platform.Network.TriggerService/Services/TriggerActionReloadService.cs
+++ b/SensateIoT.Platform.Network.TriggerService/Services/TriggerActionReloadService.cs
@@ -30,7 +30,7 @@ namespace SensateIoT.Platform.Network.TriggerService.Services
 			this.m_provider = provider;
 		}
 
-		public override async Task ExecuteAsync(CancellationToken token)
+		protected override async Task ExecuteAsync(CancellationToken token)
 		{
 			this.m_logger.LogInformation("Loading trigger actions from database.");
 			var sw = Stopwatch.StartNew();

--- a/SensateIoT.Platform.Network.TriggerService/Services/TriggerActionReloadService.cs
+++ b/SensateIoT.Platform.Network.TriggerService/Services/TriggerActionReloadService.cs
@@ -23,7 +23,7 @@ namespace SensateIoT.Platform.Network.TriggerService.Services
 										  IServiceProvider provider,
 										  ITriggerActionCache cache,
 										  ILogger<TriggerActionReloadService> logger) :
-			base(settings.Value.StartDelay, settings.Value.Interval)
+			base(settings.Value.StartDelay, settings.Value.Interval, logger)
 		{
 			this.m_logger = logger;
 			this.m_cache = cache;


### PR DESCRIPTION
In some situations, errors are hard to trace back to their origin. This PR improves logging.

## Description
Logging exists to trace errors back to their cause. Logging on the platform was not always sufficient, as uncaught exceptions in background service would go unnoticed as they are not logged to the default logger. This issue fixes #21. This PR adds a fatal crash when exceptions are not handled and timestamps to the Live Data Service logs.

## Motivation and Context
Improve bug hunting by improving the ability to trace a problem to its origin.

## How Has This Been Tested?
Manual tests have been performed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

