### PR TITLE
Fix unsubscribe routing issue's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Subscription count tracking
+- Log scopes to the Live Data Service log template
+
+### Updated
+- Project dependency's
+- Live Data Service log statement template
+
 ## [1.6.1] - 04-04-2021
 ### Added
 - Exception handing to services

--- a/SensateIoT.Platform.Network.API/SensateIoT.Platform.Network.API.csproj
+++ b/SensateIoT.Platform.Network.API/SensateIoT.Platform.Network.API.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Network.Adapters/SensateIoT.Platform.Network.Adapters.csproj
+++ b/SensateIoT.Platform.Network.Adapters/SensateIoT.Platform.Network.Adapters.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
-    <PackageReference Include="Twilio" Version="5.57.0" />
+    <PackageReference Include="Twilio" Version="5.58.0" />
   </ItemGroup>
 
 

--- a/SensateIoT.Platform.Network.Common/SensateIoT.Platform.Network.Common.csproj
+++ b/SensateIoT.Platform.Network.Common/SensateIoT.Platform.Network.Common.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.12.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.12.2" />
     <PackageReference Include="MQTTnet" Version="3.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />

--- a/SensateIoT.Platform.Network.Contracts/SensateIoT.Platform.Network.Contracts.csproj
+++ b/SensateIoT.Platform.Network.Contracts/SensateIoT.Platform.Network.Contracts.csproj
@@ -31,10 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.7" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.15.7" />
-    <PackageReference Include="Grpc" Version="2.36.4" />
-    <PackageReference Include="Grpc.Tools" Version="2.36.4">
+    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.15.8" />
+    <PackageReference Include="Grpc" Version="2.37.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.37.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
+++ b/SensateIoT.Platform.Network.Data/SensateIoT.Platform.Network.Data.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.12.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.12.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.12.2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/SensateIoT.Platform.Network.DataAccess/SensateIoT.Platform.Network.DataAccess.csproj
+++ b/SensateIoT.Platform.Network.DataAccess/SensateIoT.Platform.Network.DataAccess.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.12.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.2" />
     <PackageReference Include="Npgsql" Version="5.0.4" />
   </ItemGroup>
 

--- a/SensateIoT.Platform.Network.LiveDataService/Dockerfile
+++ b/SensateIoT.Platform.Network.LiveDataService/Dockerfile
@@ -6,7 +6,7 @@
 #
 
 # Build stage
-FROM node:15.6.0-alpine AS builder
+FROM node:14-alpine AS builder
 
 WORKDIR /usr/src/app
 
@@ -18,7 +18,7 @@ COPY SensateIoT.Platform.Network.LiveDataService/src ./src
 RUN npm ci --quit && mkdir generated && npm run generate-js-docker && npm run generate-ts && npm run build
 
 # Production stage
-FROM node:15.6.0-alpine
+FROM node:14-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/SensateIoT.Platform.Network.LiveDataService/SensateIoT.Platform.Network.LiveDataService.njsproj
+++ b/SensateIoT.Platform.Network.LiveDataService/SensateIoT.Platform.Network.LiveDataService.njsproj
@@ -24,7 +24,7 @@
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <TypeScriptSourceMap>true</TypeScriptSourceMap>
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
-    <TypeScriptToolsVersion>4.0</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>4.2</TypeScriptToolsVersion>
     <EnableTypeScript>true</EnableTypeScript>
     <StartWebBrowser>False</StartWebBrowser>
   </PropertyGroup>

--- a/SensateIoT.Platform.Network.LiveDataService/package-lock.json
+++ b/SensateIoT.Platform.Network.LiveDataService/package-lock.json
@@ -150,9 +150,9 @@
       "dev": true
     },
     "@types/mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-j0WPV+MQArOYULfCcBALomTXsDMt3iQl8dHa99jrf4U9ENgTQC3LKJbeXYL7TiClofzFOwwICkxEdlB5XhihGw==",
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
+      "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -2421,9 +2421,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ultron": {

--- a/SensateIoT.Platform.Network.LiveDataService/package.json
+++ b/SensateIoT.Platform.Network.LiveDataService/package.json
@@ -21,14 +21,14 @@
     "@types/async": "^2.4.2",
     "@types/express": "^4.17.8",
     "@types/jsonwebtoken": "^8.5.1",
-    "@types/mongodb": "^3.6.11",
+    "@types/mongodb": "^3.6.12",
     "@types/mongoose": "^5.10.4",
     "@types/node": "^8.10.64",
     "@types/pg": "^7.14.11",
     "@types/ws": "^6.0.4",
     "nodemon": "^2.0.4",
     "ts-node": "^8.10.2",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "async": "^2.6.3",

--- a/SensateIoT.Platform.Network.LiveDataService/src/app/live-data-service.ts
+++ b/SensateIoT.Platform.Network.LiveDataService/src/app/live-data-service.ts
@@ -11,7 +11,7 @@ function setupInfo() {
 
     console.log = function () {
         const args = [].slice.call(arguments);
-        const ts = `[${getTimestamp()}]: `;
+        const ts = `[${getTimestamp()}][INFO]: `;
         origLog.apply(console.log, [ts].concat(args));
     }
 }
@@ -21,7 +21,7 @@ function setupDebug() {
 
     console.debug = function () {
         const args = [].slice.call(arguments);
-        const ts = `[${getTimestamp()}]: `;
+        const ts = `[${getTimestamp()}][DEBUG]: `;
         origLog.apply(console.debug, [ts].concat(args));
     }
 }
@@ -31,7 +31,7 @@ function setupError() {
 
     console.error = function () {
         const args = [].slice.call(arguments);
-        const ts = `[${getTimestamp()}]: `;
+        const ts = `[${getTimestamp()}][ERROR]: `;
         origLog.apply(console.error, [ts].concat(args));
     }
 }

--- a/SensateIoT.Platform.Network.LiveDataService/src/models/subscription.ts
+++ b/SensateIoT.Platform.Network.LiveDataService/src/models/subscription.ts
@@ -1,0 +1,29 @@
+/*
+ * Sensor subscription model.
+ * 
+ * @author Michel Megens
+ * @email  michel@michelmegens.net
+ */
+
+import { Sensor, SensorModel } from "../models/sensor";
+
+export class Subscription {
+    public sensor: SensorModel;
+    public count: number;
+
+    public Subscription() {
+        this.count = 0;
+    }
+
+    public add() {
+        this.count += 1;
+    }
+
+    public remove() {
+        this.count -= 1;
+    }
+
+    public empty() {
+        return this.count <= 0;
+    }
+}

--- a/SensateIoT.Platform.Network.LoadTest/SensateIoT.Platform.Network.LoadTest.csproj
+++ b/SensateIoT.Platform.Network.LoadTest/SensateIoT.Platform.Network.LoadTest.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.12.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.12.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 

--- a/SensateIoT.Platform.Network.Router/SensateIoT.Platform.Network.Router.csproj
+++ b/SensateIoT.Platform.Network.Router/SensateIoT.Platform.Network.Router.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.7" />
-    <PackageReference Include="Grpc" Version="2.36.4" />
+    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Grpc" Version="2.37.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.36.0" />
     <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.36.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />

--- a/SensateIoT.Platform.Network.Router/appsettings.Development.json
+++ b/SensateIoT.Platform.Network.Router/appsettings.Development.json
@@ -10,10 +10,11 @@
       "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Sensate"
     },
     "Networking": {
-      "ConnectionString": "User ID = sql_router;Password=DefaultPassword;Server=localhost;Port=5432;Database=Networking"
+      "ConnectionString": "User ID = postgres;Password=DefaultPassword;Server=localhost;Port=5432;Database=Networking"
     },
     "MongoDB": {
-      "ConnectionString": "mongodb://root:root@localhost:27017/SensateIoT?authSource=admin"
+      "ConnectionString": "mongodb://root:root@localhost:27017/Sensate?authSource=admin",
+      "DatabaseName": "Sensate"
     }
   },
   "Mqtt": {
@@ -34,7 +35,7 @@
   },
   "HttpServer": {
     "Metrics": {
-      "Port": 5001,
+      "Port": 6501,
       "Endpoint": "metrics/",
       "Hostname": "localhost"
     }

--- a/SensateIoT.Platform.Network.StorageService/appsettings.Development.json
+++ b/SensateIoT.Platform.Network.StorageService/appsettings.Development.json
@@ -7,8 +7,8 @@
 
   "Database": {
     "MongoDB": {
-      "DatabaseName": "SensateIoT",
-      "ConnectionString": "mongodb://root:root@localhost:27017/SensateIoT?authSource=admin"
+      "DatabaseName": "Sensate",
+      "ConnectionString": "mongodb://root:root@localhost:27017/Sensate?authSource=admin"
     }
   },
   "HttpServer": {


### PR DESCRIPTION
Fix broken routing due live data unsubscribe messages sent to the message routers while there service has other subscribers.

## Description
The message routers do not track how many subscribers each Live Data Service has for a specific sensor. This functionality is delegated to the Live Data Service. The Live Data Service did not track this information either, meaning the subscriptions and routes could be deleted from the message router while other clients are still subscribed to a sensor. This patch keeps track of the amount of subscriptions to a sensor in the Live Data Service.

## Motivation and Context
Live data clients can miss out on data due to this routing bug. This fix allows multiple clients to subscribe to the same sensor. This PR fixes #24.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

